### PR TITLE
Split to nut container

### DIFF
--- a/src/video_transcoding/strategy.py
+++ b/src/video_transcoding/strategy.py
@@ -10,7 +10,7 @@ from video_transcoding.transcoding import (
     profiles,
     metadata,
     transcoder,
-    analysis,
+    extract,
 )
 from video_transcoding.utils import LoggerMixin
 
@@ -267,7 +267,7 @@ class ResumableStrategy(Strategy):
         Runs source file analysis
         :return: source file metadata.
         """
-        src = analysis.SourceExtractor().get_meta_data(self.source_uri)
+        src = extract.SourceExtractor().get_meta_data(self.source_uri)
         return src
 
     def select_profile(self, src: metadata.Metadata) -> profiles.Profile:

--- a/src/video_transcoding/strategy.py
+++ b/src/video_transcoding/strategy.py
@@ -133,11 +133,11 @@ class ResumableStrategy(Strategy):
         return self.sources.file('source.json')
 
     @property
-    def source_manifest(self) -> workspace.File:
+    def split_metadata(self) -> workspace.File:
         """
-        :return: An m3u8 manifest file for downloaded source.
+        :return: A json file with metadata for split file.
         """
-        return self.sources.file('source.m3u8')
+        return self.sources.file('split.json')
 
     @property
     def video_playlist_file(self) -> workspace.File:
@@ -306,11 +306,10 @@ class ResumableStrategy(Strategy):
         :param src: remote source metadata.
         :return: a list of chunk filenames.
         """
-        f = self.metadata_file(self.source_manifest)
+        f = self.split_metadata
         if self.ws.exists(f):
-            # m3u8 playlist already written after split finished, reuse it
-            self.logger.debug("Source already downloaded to %s",
-                              self.source_manifest)
+            # split metadata is already written after playlists finished, reuse it
+            self.logger.debug("Source already split to %s", self.split_metadata)
             content = self.ws.read(f)
             data = json.loads(content)
             meta = metadata.Metadata.from_native(data)
@@ -325,7 +324,7 @@ class ResumableStrategy(Strategy):
         """
         Downloads source file and split it to chunks at shared webdav.
         """
-        destination = self.ws.get_absolute_uri(self.source_manifest)
+        destination = self.ws.get_absolute_uri(self.split_metadata)
         split = transcoder.Splitter(
             self.source_uri,
             destination.geturl(),

--- a/src/video_transcoding/strategy.py
+++ b/src/video_transcoding/strategy.py
@@ -10,8 +10,8 @@ from video_transcoding.transcoding import (
     profiles,
     metadata,
     transcoder,
+    analysis,
 )
-from video_transcoding.transcoding.metadata import Analyzer
 from video_transcoding.utils import LoggerMixin
 
 
@@ -267,7 +267,7 @@ class ResumableStrategy(Strategy):
         Runs source file analysis
         :return: source file metadata.
         """
-        src = metadata.Analyzer().get_meta_data(self.source_uri)
+        src = analysis.SourceExtractor().get_meta_data(self.source_uri)
         return src
 
     def select_profile(self, src: metadata.Metadata) -> profiles.Profile:

--- a/src/video_transcoding/transcoding/analysis.py
+++ b/src/video_transcoding/transcoding/analysis.py
@@ -1,0 +1,87 @@
+import abc
+import json
+from typing import List, cast, Dict, Any
+
+from pymediainfo import MediaInfo
+
+from fffw.analysis import ffprobe, mediainfo
+from fffw.graph import meta
+from video_transcoding.transcoding.ffprobe import FFProbe
+from video_transcoding.transcoding.metadata import Metadata
+from video_transcoding.utils import LoggerMixin
+
+
+class Extractor(LoggerMixin, abc.ABC):
+    @abc.abstractmethod
+    def get_meta_data(self, uri: str) -> Metadata:
+        raise NotImplementedError()
+
+    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
+        self.logger.debug("Probing %s", uri)
+        ff = FFProbe(uri, show_format=True, show_streams=True, output_format='json', **kwargs)
+        self.logger.debug('[%s] %s', timeout, ff.get_cmd())
+        ret, output, errors = ff.run(timeout=timeout)
+        if ret != 0:
+            raise RuntimeError(f"ffprobe returned {ret}")
+        return ffprobe.ProbeInfo(**json.loads(output))
+
+    def mediainfo(self, uri: str) -> MediaInfo:
+        self.logger.debug("Mediainfo %s", uri)
+        return MediaInfo.parse(uri)
+
+
+class SourceAnalyzer(mediainfo.Analyzer):
+    """
+    Versatile source media analyzer.
+    """
+
+
+class SourceExtractor(Extractor):
+
+    def get_meta_data(self, uri: str) -> Metadata:
+        info = self.mediainfo(uri)
+        video_streams: List[meta.VideoMeta] = []
+        audio_streams: List[meta.AudioMeta] = []
+        for s in SourceAnalyzer(info).analyze():
+            if isinstance(s, meta.VideoMeta):
+                video_streams.append(s)
+            elif isinstance(s, meta.AudioMeta):
+                audio_streams.append(s)
+        return Metadata(
+            uri=uri,
+            videos=video_streams,
+            audios=audio_streams,
+        )
+
+
+class NutPlaylistAnalyzer(ffprobe.Analyzer):
+    """
+    Analyzer for HLS with .NUT fragments.
+    """
+
+    def get_duration(self, track: Dict[str, Any]) -> meta.TS:
+        duration = super().get_duration(track)
+        if not duration and len(self.info.streams) == 1:
+            duration = self.maybe_parse_duration(self.info.format.get('duration'))
+        return duration
+
+
+class SplitExtractor(Extractor):
+    """
+    Extracts source metadata from video and audio HLS playlists.
+    """
+
+    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
+        kwargs.setdefault('allowed_extensions', 'nut')
+        return super().ffprobe(uri, timeout, **kwargs)
+
+    def get_meta_data(self, uri: str) -> Metadata:
+        video_uri = uri.replace('/split.json', '/source-video.m3u8')
+        video_streams = NutPlaylistAnalyzer(self.ffprobe(video_uri)).analyze()
+        audio_uri = uri.replace('/split.json', '/source-audio.m3u8')
+        audio_streams = NutPlaylistAnalyzer(self.ffprobe(audio_uri)).analyze()
+        return Metadata(
+            uri=uri,
+            videos=cast(List[meta.VideoMeta], video_streams),
+            audios=cast(List[meta.AudioMeta], audio_streams),
+        )

--- a/src/video_transcoding/transcoding/analysis.py
+++ b/src/video_transcoding/transcoding/analysis.py
@@ -1,87 +1,27 @@
-import abc
-import json
-from typing import List, cast, Dict, Any
-
-from pymediainfo import MediaInfo
+from typing import Dict, Any
 
 from fffw.analysis import ffprobe, mediainfo
 from fffw.graph import meta
-from video_transcoding.transcoding.ffprobe import FFProbe
-from video_transcoding.transcoding.metadata import Metadata
-from video_transcoding.utils import LoggerMixin
-
-
-class Extractor(LoggerMixin, abc.ABC):
-    @abc.abstractmethod
-    def get_meta_data(self, uri: str) -> Metadata:
-        raise NotImplementedError()
-
-    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
-        self.logger.debug("Probing %s", uri)
-        ff = FFProbe(uri, show_format=True, show_streams=True, output_format='json', **kwargs)
-        self.logger.debug('[%s] %s', timeout, ff.get_cmd())
-        ret, output, errors = ff.run(timeout=timeout)
-        if ret != 0:
-            raise RuntimeError(f"ffprobe returned {ret}")
-        return ffprobe.ProbeInfo(**json.loads(output))
-
-    def mediainfo(self, uri: str) -> MediaInfo:
-        self.logger.debug("Mediainfo %s", uri)
-        return MediaInfo.parse(uri)
 
 
 class SourceAnalyzer(mediainfo.Analyzer):
     """
-    Versatile source media analyzer.
+    Universal source media analyzer.
     """
-
-
-class SourceExtractor(Extractor):
-
-    def get_meta_data(self, uri: str) -> Metadata:
-        info = self.mediainfo(uri)
-        video_streams: List[meta.VideoMeta] = []
-        audio_streams: List[meta.AudioMeta] = []
-        for s in SourceAnalyzer(info).analyze():
-            if isinstance(s, meta.VideoMeta):
-                video_streams.append(s)
-            elif isinstance(s, meta.AudioMeta):
-                audio_streams.append(s)
-        return Metadata(
-            uri=uri,
-            videos=video_streams,
-            audios=audio_streams,
-        )
 
 
 class NutPlaylistAnalyzer(ffprobe.Analyzer):
     """
-    Analyzer for HLS with .NUT fragments.
+    Analyzer for HLS playlist with .NUT fragments.
     """
 
     def get_duration(self, track: Dict[str, Any]) -> meta.TS:
+        """
+        Augment track duration with a value from container.
+
+        This is legit if media contains only a single stream.
+        """
         duration = super().get_duration(track)
         if not duration and len(self.info.streams) == 1:
             duration = self.maybe_parse_duration(self.info.format.get('duration'))
         return duration
-
-
-class SplitExtractor(Extractor):
-    """
-    Extracts source metadata from video and audio HLS playlists.
-    """
-
-    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
-        kwargs.setdefault('allowed_extensions', 'nut')
-        return super().ffprobe(uri, timeout, **kwargs)
-
-    def get_meta_data(self, uri: str) -> Metadata:
-        video_uri = uri.replace('/split.json', '/source-video.m3u8')
-        video_streams = NutPlaylistAnalyzer(self.ffprobe(video_uri)).analyze()
-        audio_uri = uri.replace('/split.json', '/source-audio.m3u8')
-        audio_streams = NutPlaylistAnalyzer(self.ffprobe(audio_uri)).analyze()
-        return Metadata(
-            uri=uri,
-            videos=cast(List[meta.VideoMeta], video_streams),
-            audios=cast(List[meta.AudioMeta], audio_streams),
-        )

--- a/src/video_transcoding/transcoding/extract.py
+++ b/src/video_transcoding/transcoding/extract.py
@@ -1,0 +1,70 @@
+import abc
+import json
+from typing import List, cast
+
+from pymediainfo import MediaInfo
+
+from fffw.analysis import ffprobe
+from fffw.graph import meta
+from video_transcoding.transcoding.analysis import SourceAnalyzer, NutPlaylistAnalyzer
+from video_transcoding.transcoding.ffprobe import FFProbe
+from video_transcoding.transcoding.metadata import Metadata
+from video_transcoding.utils import LoggerMixin
+
+
+class Extractor(LoggerMixin, abc.ABC):
+    @abc.abstractmethod
+    def get_meta_data(self, uri: str) -> Metadata:
+        raise NotImplementedError()
+
+    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
+        self.logger.debug("Probing %s", uri)
+        ff = FFProbe(uri, show_format=True, show_streams=True, output_format='json', **kwargs)
+        self.logger.debug('[%s] %s', timeout, ff.get_cmd())
+        ret, output, errors = ff.run(timeout=timeout)
+        if ret != 0:
+            raise RuntimeError(f"ffprobe returned {ret}")
+        return ffprobe.ProbeInfo(**json.loads(output))
+
+    def mediainfo(self, uri: str) -> MediaInfo:
+        self.logger.debug("Mediainfo %s", uri)
+        return MediaInfo.parse(uri)
+
+
+class SourceExtractor(Extractor):
+
+    def get_meta_data(self, uri: str) -> Metadata:
+        info = self.mediainfo(uri)
+        video_streams: List[meta.VideoMeta] = []
+        audio_streams: List[meta.AudioMeta] = []
+        for s in SourceAnalyzer(info).analyze():
+            if isinstance(s, meta.VideoMeta):
+                video_streams.append(s)
+            elif isinstance(s, meta.AudioMeta):
+                audio_streams.append(s)
+        return Metadata(
+            uri=uri,
+            videos=video_streams,
+            audios=audio_streams,
+        )
+
+
+class SplitExtractor(Extractor):
+    """
+    Extracts source metadata from video and audio HLS playlists.
+    """
+
+    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
+        kwargs.setdefault('allowed_extensions', 'nut')
+        return super().ffprobe(uri, timeout, **kwargs)
+
+    def get_meta_data(self, uri: str) -> Metadata:
+        video_uri = uri.replace('/split.json', '/source-video.m3u8')
+        video_streams = NutPlaylistAnalyzer(self.ffprobe(video_uri)).analyze()
+        audio_uri = uri.replace('/split.json', '/source-audio.m3u8')
+        audio_streams = NutPlaylistAnalyzer(self.ffprobe(audio_uri)).analyze()
+        return Metadata(
+            uri=uri,
+            videos=cast(List[meta.VideoMeta], video_streams),
+            audios=cast(List[meta.AudioMeta], audio_streams),
+        )

--- a/src/video_transcoding/transcoding/extract.py
+++ b/src/video_transcoding/transcoding/extract.py
@@ -1,6 +1,6 @@
 import abc
 import json
-from typing import List, cast
+from typing import List, cast, Any
 
 from pymediainfo import MediaInfo
 
@@ -17,7 +17,7 @@ class Extractor(LoggerMixin, abc.ABC):
     def get_meta_data(self, uri: str) -> Metadata:
         raise NotImplementedError()
 
-    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
+    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs: Any) -> ffprobe.ProbeInfo:
         self.logger.debug("Probing %s", uri)
         ff = FFProbe(uri, show_format=True, show_streams=True, output_format='json', **kwargs)
         self.logger.debug('[%s] %s', timeout, ff.get_cmd())
@@ -54,7 +54,7 @@ class SplitExtractor(Extractor):
     Extracts source metadata from video and audio HLS playlists.
     """
 
-    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs) -> ffprobe.ProbeInfo:
+    def ffprobe(self, uri: str, timeout: float = 60.0, **kwargs: Any) -> ffprobe.ProbeInfo:
         kwargs.setdefault('allowed_extensions', 'nut')
         return super().ffprobe(uri, timeout, **kwargs)
 

--- a/src/video_transcoding/transcoding/ffprobe.py
+++ b/src/video_transcoding/transcoding/ffprobe.py
@@ -1,28 +1,15 @@
 from dataclasses import dataclass
+from typing import Optional
 
-from fffw.wrapper import BaseWrapper, param
+from fffw.encoding import ffprobe
 
 
 @dataclass
-class FFProbe(BaseWrapper):
+class FFProbe(ffprobe.FFProbe):
     """
-    ffprobe command line basic wrapper.
-
-    >>> from fffw.encoding.codecs import VideoCodec, AudioCodec
-    >>> from fffw.encoding.filters import Scale
-    >>> from fffw.encoding.outputs import output_file
-    >>> ff = FFProbe('/tmp/input.mp4', show_streams=True, show_format=True,
-    ...     output_format='json')
-    >>> ff.get_cmd()
-    'ffprobe -show_streams -show_format -of json /tmp/input.mp4'
-    >>>
+    Extends ffprobe wrapper with new arguments and output filtering.
     """
-    command = 'ffprobe'
-    input: str = param(name='i')
-    show_streams: bool = param(default=False)
-    show_format: bool = param(default=False)
-    output_format: str = param(name='of')
-    loglevel: str = param()
+    allowed_extensions: Optional[str] = None
 
     def handle_stderr(self, line: str) -> str:
         if '[error]' in line:
@@ -31,4 +18,3 @@ class FFProbe(BaseWrapper):
 
     def handle_stdout(self, line: str) -> str:
         return line
-

--- a/src/video_transcoding/transcoding/outputs.py
+++ b/src/video_transcoding/transcoding/outputs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Dict, Any
 
 from fffw.encoding.outputs import Output
 from fffw.wrapper import param
@@ -14,6 +14,28 @@ class HLSOutput(Output):
     master_pl_name: Optional[str] = None
     muxdelay: Optional[str] = None
     copyts: bool = param(default=False)
+
+
+def render_opts(value: Dict[str, Any]) -> str:
+    """
+    Formatter for segment_format_options option for segment muxer.
+
+    > -segment_format_options <dictionary> ... set list of options for the container format used for the segments
+    """
+    return ':'.join(f'{k}={v}' for k, v in value.items())
+
+
+@dataclass
+class SegmentOutput(Output):
+    """
+    Segment muxer
+    """
+    segment_format: Optional[str] = None
+    segment_format_options: Optional[dict] = param(render=render_opts)
+    segment_list: Optional[str] = None
+    segment_list_type: Optional[str] = None
+    segment_time: Optional[float] = None
+    min_seg_duration: Optional[float] = None
 
 
 @dataclass

--- a/src/video_transcoding/transcoding/transcoder.py
+++ b/src/video_transcoding/transcoding/transcoder.py
@@ -9,7 +9,7 @@ from fffw.encoding.vector import SIMD, Vector
 from fffw.graph import VIDEO, AUDIO
 
 from video_transcoding import defaults
-from video_transcoding.transcoding import codecs, outputs, analysis
+from video_transcoding.transcoding import codecs, outputs, extract
 from video_transcoding.transcoding.metadata import Metadata, rational
 from video_transcoding.transcoding.profiles import Profile
 from video_transcoding.utils import LoggerMixin
@@ -171,7 +171,7 @@ class Splitter(Processor):
     """
 
     def get_result_metadata(self, uri: str) -> Metadata:
-        dst = analysis.SplitExtractor().get_meta_data(uri)
+        dst = extract.SplitExtractor().get_meta_data(uri)
         # Mediainfo takes metadata from first HLS chunk in a playlist, so
         # we need to force some fields from source metadata
         if len(self.meta.videos) != len(dst.videos):


### PR DESCRIPTION
To support any source format (not restricted by closed list defined in HLS/MPEGTS standards), we need to split source file to segments (with `segment` muxer) and to store source streams in a generic (`.nut`) container not restricted by supported codecs list (maybe `mkv` also is acceptable, but there are issues with `libfdk_aac`).

Changes:

1. Introduce extractors for overriding metadata analysis implementation
2. Change `hls` muxer to `segment`
3. Analyze video and audio playlists separately
4. Augment result metadata with data from container for single-stream files
5. Use audio-codec copy at split phase
6. ...